### PR TITLE
Fix minor code style typo (getButton)

### DIFF
--- a/src/CustomTextButton.lua
+++ b/src/CustomTextButton.lua
@@ -84,7 +84,10 @@ function CustomTextButtonClass:_updateButtonVisual()
 	end
 end
 
-function CustomTextButtonClass:getButton()
+-- Backwards compatibility (should be removed in the future)
+-- CustomTextButtonClass.getButton = CustomTextButtonClass.GetButton
+
+function CustomTextButtonClass:GetButton()
 	return self._button
 end
 


### PR DESCRIPTION
Renamed getButton to GetButton, as according to the repo's coding style, and added a (commented) reference with the old method name so existing code does not break.

(solves Issue #13)