### PR TITLE
README.md uses deprecated and non-existent getButton method

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ local button = CustomTextButton.new(
 )
 
 -- use the :getButton() method to return the ImageButton gui object
-local buttonObject = button:getButton()
+local buttonObject = button:GetButton()
 buttonObject.Size = UDim2.new(0, 70, 0, 25)
 
 buttonObject.MouseButton1Click:Connect(function()


### PR DESCRIPTION
Lines 90-92 of the [CustomTextButton](https://github.com/Roblox/StudioWidgets/tree/master/src/CustomTextButton.lua) module, `:GetButton` function is declared.

```Lua
function CustomTextButtonClass:GetButton()
	return self._button
end
```

Documentation uses `:getButton()`, which was causing an error when I tried to use the example provided in docs. Turns out it was deprecated and removed in favour of the CamalCase variant.